### PR TITLE
HTTP Transport dependency injection

### DIFF
--- a/request.go
+++ b/request.go
@@ -33,10 +33,12 @@ import (
 
 func request(url string, data string, isPost bool) (response *http.Response, err error) {
 	buf := bytes.NewBufferString(data)
+	client := &http.Client{Transport: Transport}
+
 	if isPost {
-		response, err = http.Post(url, "text/plain", buf)
+		response, err = client.Post(url, "text/plain", buf)
 	} else {
-		response, err = http.Get(url)
+		response, err = client.Get(url)
 	}
 	if err != nil {
 		_, filename, line_no, _ := runtime.Caller(0)

--- a/safebrowsing.go
+++ b/safebrowsing.go
@@ -64,6 +64,7 @@ var Logger logger = new(DefaultLogger)
 var Client string = "api"
 var AppVersion string = "1.0"
 var OfflineMode bool = false
+var Transport *http.Transport = &http.Transport{}
 
 func NewSafeBrowsing(apiKey string, dataDirectory string) (ss *SafeBrowsing, err error) {
 	ss = &SafeBrowsing{


### PR DESCRIPTION
This allows passing of HTTP transport objects, e.g., for usage of a proxy or definition of specific CA root store locations.