### PR TITLE
only lock updates around the actual update

### DIFF
--- a/checkurl.go
+++ b/checkurl.go
@@ -28,6 +28,7 @@ package safebrowsing
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -72,13 +73,15 @@ func (sb *SafeBrowsing) MightBeListed(url string) (list string, fullHashMatch bo
 	return sb.queryUrl(url, false)
 }
 
+var ErrOutOfDateHashes = errors.New("Unable to check listing, list hasn't been updated for 45 mins")
+
 // Here is where we actually look up the hashes against our map.
 func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, fullHashMatch bool, err error) {
 	//	defer debug.FreeOSMemory()
 
 	if matchFullHash && !sb.IsUpToDate() {
 		// we haven't had a sucessful update in the last 45 mins!  abort!
-		return "", false, fmt.Errorf("Unable to check listing, list hasn't been updated for 45 mins")
+		return "", false, ErrOutOfDateHashes
 	}
 
 	// first Canonicalize


### PR DESCRIPTION
This introduces a new fsLock that will lock around both the updates and the file system effects to allow code reading from the tries to make forward motion while preventing other filesystem modifications at the same time.

It also moves the updateLock to updateLookupMap.

Depending on how heavy the trie operations are in updateLookupMap and how large the tries get, we may want to either a) clone the tries and then pointer swap them in or b) make the locks occur only around each exact operation. For instance, in the PREFIX_4B_SZ, CHUNK_TYPE_SUB case, we could allow the Lookup.Delete to occur in a write lock, take a read lock to pull the data from the FullHashes iterator, and only then go back with a write lock around with a write lock around each individual FullHashes.Delete.

Since all of this happens under fsLock, we don't have worry about multiple SafeBrowsingList.load calls stomping on each other's toes.

This also includes #13 and it should be reviewed, as well.