### PR TITLE
fix v3 key parameter name

### DIFF
--- a/safebrowsing.go
+++ b/safebrowsing.go
@@ -144,8 +144,8 @@ func (sb *SafeBrowsing) requestSafeBrowsingLists() (err error) {
 
 	url := fmt.Sprintf(
 		"https://safebrowsing.google.com/safebrowsing/list?"+
-			"client=%s&apikey=%s&appver=%s&pver=%s",
-		sb.Client, sb.Key, sb.AppVersion, sb.ProtocolVersion)
+			"client=%s&%s=%s&appver=%s&pver=%s",
+		sb.Client, sb.keyParam(), sb.Key, sb.AppVersion, sb.ProtocolVersion)
 
 	listresp, err := sb.request(url, "", true)
 	if err != nil {
@@ -212,8 +212,8 @@ func (sb *SafeBrowsing) requestRedirectList() (err error, status int) {
 
 	url := fmt.Sprintf(
 		"https://safebrowsing.google.com/safebrowsing/downloads?"+
-			"client=%s&apikey=%s&appver=%s&pver=%s",
-		sb.Client, sb.Key, sb.AppVersion, sb.ProtocolVersion)
+			"client=%s&%s=%s&appver=%s&pver=%s",
+		sb.Client, sb.keyParam(), sb.Key, sb.AppVersion, sb.ProtocolVersion)
 
 	listsStr := ""
 	for list, sbl := range sb.Lists {
@@ -363,4 +363,13 @@ func (sb *SafeBrowsing) reloadLoop() {
 		}
 		//		debug.FreeOSMemory()
 	}
+}
+
+const v3KeyPrefix = "AIza"
+
+func (sb *SafeBrowsing) keyParam() string {
+	if strings.HasPrefix(sb.Key, v3KeyPrefix) {
+		return "key"
+	}
+	return "apikey"
 }


### PR DESCRIPTION
A recent change to the GSB API switched v2 keys to use the 'apikey' parameter and v3 keys to use the 'key' parameter. The version of the key can be detected by checking for the v3 prefix: `AIza`