### PR TITLE
combined PR for PR19/PR20/PR21

### DIFF
--- a/checkurl.go
+++ b/checkurl.go
@@ -90,11 +90,12 @@ func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, f
 	urls := GenerateTestCandidates(url)
 	//      sb.Logger.Debug("Checking %d iterations of url", len(urls))
 	for list, sbl := range sb.Lists {
+
+		// create the map for all prefixes we need to do the full hash lookup
+		keysToLookupMap := make(map[LookupHash]bool)
+
 		for _, url := range urls {
 
-			hostKey := ExtractHostKey(url)
-			hostKeyHash := HostHash(getHash(hostKey)[:4])
-			//                      sb.Logger.Debug("Host hash: %s", hex.EncodeToString([]byte(hostKeyHash)))
 			sbl.updateLock.RLock()
 			// hash it up
 			//                      sb.Logger.Debug("Hashing %s", url)
@@ -104,15 +105,10 @@ func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, f
 			lookupHash := string(prefix)
 			fullLookupHash := string(urlHash)
 
-			//                        sb.Logger.Debug("testing hash: %s, full = %s",
-			//                                hex.EncodeToString([]byte(lookupHash)),
-			//                                hex.EncodeToString([]byte(fullLookupHash)))
-
-			fhc, ok := sb.Cache[hostKeyHash]
+			fhc, ok := sbl.Cache[FullHash(fullLookupHash)]
 			if ok && !fhc.checkValidity() {
-				delete(sb.Cache, hostKeyHash)
-				//                sbl.Logger.Debug("Delete full length hash: %s",
-				//					hex.EncodeToString([]byte(fullLookupHash)))
+				delete(sbl.Cache, FullHash(fullLookupHash))
+				//sbl.Logger.Debug("Delete full length hash: %s",fullLookupHash)
 				sbl.FullHashRequested.Delete(lookupHash)
 				sbl.FullHashes.Delete(fullLookupHash)
 			}
@@ -123,7 +119,6 @@ func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, f
 			}
 
 			// now see if there is a match in our prefix trie
-			keysToLookupMap := make(map[LookupHash]bool)
 			if sbl.Lookup.Get(lookupHash) {
 				if !matchFullHash || OfflineMode {
 					//					sb.Logger.Debug("Partial hash hit")
@@ -143,16 +138,20 @@ func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, f
 
 				keysToLookupMap[prefix] = true
 			}
+		}
 
-			sbl.updateLock.RUnlock()
-			if len(keysToLookupMap) > 0 {
-				err := sb.requestFullHashes(list, hostKeyHash, keysToLookupMap)
-				if err != nil {
-					return "", false, err
-				}
-				sbl.updateLock.RLock()
+		// Check if we need to do a fullHashLookup
+		if len(keysToLookupMap) > 0 {
+			err := sb.requestFullHashes(list, keysToLookupMap)
+			if err != nil {
+				return "", false, err
+			}
 
-				// re-check for full hash hit.
+			// re-check for full hash hit.
+			sbl.updateLock.RLock()
+			for _, url := range urls {
+				urlHash := getHash(url)
+				fullLookupHash := string(urlHash)
 				if sbl.FullHashes.Get(string(fullLookupHash)) {
 					sbl.updateLock.RUnlock()
 					return list, true, nil
@@ -182,7 +181,7 @@ func (fhc *FullHashCache) checkValidity() bool {
 }
 
 // request full hases for a set of lookup prefixes.
-func (sb *SafeBrowsing) requestFullHashes(list string, host HostHash, prefixes map[LookupHash]bool) error {
+func (sb *SafeBrowsing) requestFullHashes(list string, prefixes map[LookupHash]bool) error {
 
 	if len(prefixes) == 0 {
 		return nil
@@ -226,7 +225,7 @@ func (sb *SafeBrowsing) requestFullHashes(list string, host HostHash, prefixes m
 	if response.StatusCode != 200 {
 		if response.StatusCode == 503 {
 			// Retry in background with a new thread
-			go sb.doFullHashBackOffRequest(host, url, body)
+			go sb.doFullHashBackOffRequest(url, body)
 			return fmt.Errorf("Service temporarily Unavailable")
 		}
 		return fmt.Errorf("Unable to lookup full hash, server returned %d",
@@ -236,11 +235,11 @@ func (sb *SafeBrowsing) requestFullHashes(list string, host HostHash, prefixes m
 	if err != nil {
 		return err
 	}
-	return sb.processFullHashes(string(data), host)
+	return sb.processFullHashes(string(data))
 }
 
 // Process the retrieved full hashes, saving them to disk
-func (sb *SafeBrowsing) processFullHashes(data string, host HostHash) (err error) {
+func (sb *SafeBrowsing) processFullHashes(data string) error {
 	//	defer debug.FreeOSMemory()
 
 	split := strings.Split(data, "\n")
@@ -252,7 +251,6 @@ func (sb *SafeBrowsing) processFullHashes(data string, host HostHash) (err error
 	if err != nil {
 		return err
 	}
-	sb.Cache[host] = newFullHashCache(time.Now(), cacheLifeTime)
 	if split_sz <= 2 {
 		return nil
 	}
@@ -272,13 +270,13 @@ func (sb *SafeBrowsing) processFullHashes(data string, host HostHash) (err error
 		} else {
 			chunk_sz = 2
 		}
-		err = sb.readFullHashChunk(split[i+1], splitsplit[0], host)
+		err = sb.readFullHashChunk(split[i+1], splitsplit[0], cacheLifeTime)
 	}
 	return err
 }
 
-func (sb *SafeBrowsing) readFullHashChunk(hashes string, list string, host HostHash) (err error) {
-	if hashes == "" || list == "" || host == "" {
+func (sb *SafeBrowsing) readFullHashChunk(hashes string, list string, cacheLifeTime int) (err error) {
+	if hashes == "" || list == "" {
 		return fmt.Errorf("Imcomplete data to readFullHashChunck()")
 	}
 
@@ -296,12 +294,13 @@ func (sb *SafeBrowsing) readFullHashChunk(hashes string, list string, host HostH
 		sb.Lists[list].updateLock.Lock()
 		sb.Lists[list].FullHashes.Set(hash)
 		sb.Lists[list].updateLock.Unlock()
+		sb.Lists[list].Cache[FullHash(hash)] = newFullHashCache(time.Now(), cacheLifeTime)
 	}
 	return nil
 }
 
 // Continue the attempt to request for full hashes in the background, observing the required backoff behaviour.
-func (sb *SafeBrowsing) doFullHashBackOffRequest(host HostHash, url string, body string) {
+func (sb *SafeBrowsing) doFullHashBackOffRequest(url string, body string) {
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	randomFloat := r.Float64()
@@ -342,12 +341,12 @@ func (sb *SafeBrowsing) doFullHashBackOffRequest(host HostHash, url string, body
 			err,
 		)
 	}
-	err = sb.processFullHashes(string(data), host)
+	err = sb.processFullHashes(string(data))
 	if err != nil {
 		sb.Logger.Error(
 			"Unable process full hashes from response in back-off mode: %s; trying again.",
 			err,
 		)
-		sb.doFullHashBackOffRequest(host, url, body)
+		sb.doFullHashBackOffRequest(url, body)
 	}
 }

--- a/checkurl.go
+++ b/checkurl.go
@@ -96,8 +96,6 @@ func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, f
 
 		for _, url := range urls {
 
-			// hash it up
-			//                      sb.Logger.Debug("Hashing %s", url)
 			urlHash := getHash(url)
 
 			prefix := urlHash[:PREFIX_4B_SZ]
@@ -142,10 +140,10 @@ func (sb *SafeBrowsing) queryUrl(url string, matchFullHash bool) (list string, f
 			}
 
 			// re-check for full hash hit.
-			sbl.updateLock.RLock()
 			for _, url := range urls {
 				urlHash := getHash(url)
 				fullLookupHash := string(urlHash)
+
 				if sbl.FullHashes.Get(string(fullLookupHash)) {
 					return list, true, nil
 				}
@@ -260,6 +258,7 @@ func (sb *SafeBrowsing) processFullHashes(data string) error {
 		} else {
 			chunk_sz = 2
 		}
+
 		err = sb.readFullHashChunk(split[i+1], splitsplit[0], cacheLifeTime)
 	}
 	return err

--- a/safebrowsing.go
+++ b/safebrowsing.go
@@ -39,7 +39,7 @@ import (
 	"time"
 )
 
-type HostHash string
+type FullHash string
 type LookupHash string
 
 type SafeBrowsing struct {
@@ -54,7 +54,6 @@ type SafeBrowsing struct {
 	LastUpdated time.Time
 
 	Lists   map[string]*SafeBrowsingList
-	Cache   map[HostHash]*FullHashCache
 	request func(string, string, bool) (*http.Response, error)
 
 	Logger logger
@@ -80,7 +79,6 @@ func NewSafeBrowsing(apiKey string, dataDirectory string) (sb *SafeBrowsing, err
 		ProtocolVersion: ProtocolVersion,
 		DataDir:         dataDirectory,
 		Lists:           make(map[string]*SafeBrowsingList),
-		Cache:           make(map[HostHash]*FullHashCache),
 		request:         request,
 		Logger:          Logger,
 	}
@@ -315,7 +313,12 @@ func (sb *SafeBrowsing) processRedirectList(buf io.Reader) error {
 
 func (sb *SafeBrowsing) reset() {
 
+	// reinitalize all lists
 	for _, sbl := range sb.Lists {
+
+		// clear cache
+		sbl.Cache = make(map[FullHash]*FullHashCache)
+
 		sbl.Lookup = NewTrie()
 		sbl.FullHashes = NewTrie()
 		sbl.FullHashRequested = NewTrie()

--- a/safebrowsing.go
+++ b/safebrowsing.go
@@ -366,6 +366,13 @@ func (sb *SafeBrowsing) reloadLoop() {
 		}
 		//		debug.FreeOSMemory()
 	}
+
+	// Recover from all panicks in reloadLoop, just to log the erros.
+	defer func() {
+		if r := recover(); r != nil {
+			sb.Logger.Error("reloadLoop panicked: %v", r)
+		}
+	}()
 }
 
 const v3KeyPrefix = "AIza"

--- a/safebrowsing_test.go
+++ b/safebrowsing_test.go
@@ -37,7 +37,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	//"strings"
-	"sync"
 )
 
 type MockReadCloser struct {
@@ -161,8 +160,8 @@ func TestUrlListed(t *testing.T) {
 					CHUNK_TYPE_ADD: make(map[ChunkNum]bool),
 					CHUNK_TYPE_SUB: make(map[ChunkNum]bool),
 				},
-				Logger:     new(DefaultLogger),
-				fsLock:     new(sync.Mutex),
+				Logger: new(DefaultLogger),
+				fsLock: new(sync.Mutex),
 			},
 		},
 		Logger:  new(DefaultLogger),

--- a/safebrowsing_test.go
+++ b/safebrowsing_test.go
@@ -156,6 +156,7 @@ func TestUrlListed(t *testing.T) {
 				Lookup:            NewTrie(),
 				FullHashRequested: NewTrie(),
 				FullHashes:        NewTrie(),
+				Cache:             make(map[FullHash]*FullHashCache),
 				DeleteChunks: map[ChunkData_ChunkType]map[ChunkNum]bool{
 					CHUNK_TYPE_ADD: make(map[ChunkNum]bool),
 					CHUNK_TYPE_SUB: make(map[ChunkNum]bool),
@@ -164,7 +165,6 @@ func TestUrlListed(t *testing.T) {
 				updateLock: new(sync.RWMutex),
 			},
 		},
-		Cache:   make(map[HostHash]*FullHashCache),
 		Logger:  new(DefaultLogger),
 		request: NewMockRequest(string(chunkData)),
 	}

--- a/safebrowsing_test.go
+++ b/safebrowsing_test.go
@@ -162,7 +162,7 @@ func TestUrlListed(t *testing.T) {
 					CHUNK_TYPE_SUB: make(map[ChunkNum]bool),
 				},
 				Logger:     new(DefaultLogger),
-				updateLock: new(sync.RWMutex),
+				fsLock:     new(sync.Mutex),
 			},
 		},
 		Logger:  new(DefaultLogger),

--- a/safebrowsinglist.go
+++ b/safebrowsinglist.go
@@ -57,12 +57,9 @@ type SafeBrowsingList struct {
 	tmpFullHashRequested *HatTrie
 
 	Logger logger
-	// fsLock is wrapped around the filesystem modifications and a call to
-	// updateLock to prevent more than one set of fs modifications happening at
-	// once.
+	// fsLock is wrapped around the filesystem modifications
+	// to prevent more than one set of fs modifications happening at once.
 	fsLock *sync.Mutex
-	// updateLock prevents more than one pointer swap
-	updateLock *sync.RWMutex
 }
 
 func newSafeBrowsingList(name string, filename string) (sbl *SafeBrowsingList) {
@@ -77,7 +74,6 @@ func newSafeBrowsingList(name string, filename string) (sbl *SafeBrowsingList) {
 		DeleteChunks:      make(map[ChunkData_ChunkType]map[ChunkNum]bool),
 		Logger:            &DefaultLogger{},
 		fsLock:            new(sync.Mutex),
-		updateLock:        new(sync.RWMutex),
 	}
 	sbl.DeleteChunks[CHUNK_TYPE_ADD] = make(map[ChunkNum]bool)
 	sbl.DeleteChunks[CHUNK_TYPE_SUB] = make(map[ChunkNum]bool)
@@ -308,8 +304,6 @@ func (sbl *SafeBrowsingList) updateLookupMap(chunk *ChunkData) {
 
 	for i := 0; (i + hashlen) <= hasheslen; i += hashlen {
 		hash := chunk.Hashes[i:(i + hashlen)]
-		// We may have to make this more fine grained
-		sbl.updateLock.Lock()
 		switch hashlen {
 		case PREFIX_4B_SZ:
 			// we are a hash-prefix
@@ -336,6 +330,5 @@ func (sbl *SafeBrowsingList) updateLookupMap(chunk *ChunkData) {
 				sbl.tmpFullHashRequested.Set(lookupHash)
 			}
 		}
-		sbl.updateLock.Unlock()
 	}
 }

--- a/safebrowsinglist.go
+++ b/safebrowsinglist.go
@@ -31,11 +31,11 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	//	"runtime/debug"
 	"sync"
+	//	"runtime/debug"
 )
 
-//import "encoding/hex"
+import "encoding/hex"
 
 type SafeBrowsingList struct {
 	Name     string
@@ -50,6 +50,11 @@ type SafeBrowsingList struct {
 	FullHashRequested *HatTrie
 	FullHashes        *HatTrie
 	Cache             map[FullHash]*FullHashCache
+
+	// Temporary lookup tables (used during update only).
+	tmpLookup            *HatTrie
+	tmpFullHashes        *HatTrie
+	tmpFullHashRequested *HatTrie
 
 	Logger logger
 	// fsLock is wrapped around the filesystem modifications and a call to
@@ -166,11 +171,14 @@ func (sbl *SafeBrowsingList) load(newChunks []*ChunkData) (err error) {
 	deletedChunkCount := 0
 	addedChunkCount := len(newChunks)
 
+	// Create new temprary map for the update.
+	sbl.tmpLookup = NewTrie()
+
 	// Just clear all Full Hashes as the GSBv3 specification requests us
 	// to delete all FullHashes on update
 	// https://developers.google.com/safe-browsing/developers_guide_v3#Changes3.0
-	sbl.FullHashes = NewTrie()
-	sbl.FullHashRequested = NewTrie()
+	sbl.tmpFullHashes = NewTrie()
+	sbl.tmpFullHashRequested = NewTrie()
 
 	// load existing chunk
 	if dec != nil {
@@ -249,6 +257,14 @@ func (sbl *SafeBrowsingList) load(newChunks []*ChunkData) (err error) {
 		}
 	}
 
+	// Replace current maps with the newly created ones.
+	sbl.Logger.Info("Replacing FullHashes and Lookup lists")
+	sbl.Lookup = sbl.tmpLookup
+	// reset the FullHashes cache and reset the pending list
+	sbl.FullHashes = sbl.tmpFullHashes
+	sbl.FullHashRequested = sbl.tmpFullHashRequested
+	sbl.Logger.Info("Replaced FullHashes and Lookup lists")
+
 	// now close off our files, discard the old and keep the new
 	if f != nil {
 		err = os.Remove(sbl.FileName)
@@ -300,28 +316,26 @@ func (sbl *SafeBrowsingList) updateLookupMap(chunk *ChunkData) {
 			prefix := string(hash)
 			switch chunk.GetChunkType() {
 			case CHUNK_TYPE_ADD:
-				sbl.Lookup.Set(prefix)
+				sbl.tmpLookup.Set(prefix)
 			case CHUNK_TYPE_SUB:
-				sbl.Lookup.Delete(prefix)
+				sbl.tmpLookup.Delete(prefix)
 			}
 		case PREFIX_32B_SZ:
 			// we are a full-length hash
 			lookupHash := string(hash)
 			switch chunk.GetChunkType() {
 			case CHUNK_TYPE_ADD:
-				//                              sbl.Logger.Debug("Adding full length hash: %s",
-				//                                      hex.EncodeToString([]byte(lookupHash)))
-				sbl.FullHashes.Set(lookupHash)
+				sbl.Logger.Debug("Adding full length hash: %s", hex.EncodeToString([]byte(lookupHash)))
+				sbl.tmpFullHashes.Set(lookupHash)
 			case CHUNK_TYPE_SUB:
-				// sbl.Logger.Debug("sub full length hash: %s", hex.EncodeToString([]byte(lookupHash)))
+				//sbl.Logger.Debug("sub full length hash: %s", hex.EncodeToString([]byte(lookupHash)))
 				// delete will do nothing if lookupHash does not exist
-				sbl.FullHashes.Delete(lookupHash)
+				sbl.tmpFullHashes.Delete(lookupHash)
 				// Mark that we have already requested this fullhash so that we don't keep asking
 				// for this hash in the feature as this chunk is a SUB chunk which removes false positives
-				sbl.FullHashRequested.Set(lookupHash)
+				sbl.tmpFullHashRequested.Set(lookupHash)
 			}
 		}
 		sbl.updateLock.Unlock()
-
 	}
 }


### PR DESCRIPTION
This PR contains all changes from PR 19, PR 20 and PR 21. Furthermore, there is a small commit which just enhances the accounting of the updates process. 

The main changes are as follows:
- better full hash cache handling (per list and cleanup on every update cycle as specified in the GSBv3 specification)
- apply updates on temporary hat-tries and swap pointers after update for speed improvements due to locking
- hat-trie implementation which autolocks on set/get/delete calls (code simplification and minor speed improvements)

We are running a daemon containing these major code changes since a couple of months in production without any issues on several thousands of hosts (with more than 1000 lookups per second to the library).

Just let me know if you need any further help on this.
Thank you very much for your efforts.

Cheers,
Daniel